### PR TITLE
Fix: incorrect build output directory structure

### DIFF
--- a/src/config/sheet.ts
+++ b/src/config/sheet.ts
@@ -17,7 +17,8 @@
  *                                                                                *
  **********************************************************************************/
 
-import rawConfig from '../../sheetconfig.json'
+import fs from 'fs'
+import path from 'path'
 
 export interface SheetConfig {
   type: string
@@ -38,6 +39,10 @@ export interface SheetConfig {
     }
   }[]
 }
+
+const rawConfig: SheetConfig[] = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '../../sheetconfig.json'), 'utf-8'),
+)
 
 export const sheetConfig = (): SheetConfig[] => {
   return rawConfig


### PR DESCRIPTION
### Bug Description

There is a problem because one of imported files (sheetconfig.json) is located outside `src` directory.

So when the typescript code is compiled (with `tsc` command), the output directory structure is like:
```bash
build
├── sheetconfig.json
└── src
    ├── config
    ├── database
    ├── index.js
    ├── index.js.map
    ├── internal
    └── service
```
we don't want that `src` directory inside `build`, but we want something like this:

```bash
build
├── config
├── database
├── index.js
├── index.js.map
├── internal
└── service
```

### How did I solve the problem?

I changed the sheetconfig.json reading from previously imported as module to file read with `fs`, so the app will keep reading the original configuration without needing to copy it to `build` directory.


### How to test?

- delete `build` directory
- Run `npx tsc` and inspect the produced `build` directory