### PR TITLE
Feat: remove outSheet from configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,11 @@ The structure of configuration file:
     "destinations": [
       {
         "kind": "patient",
-        "columns": {
-          "inSheet": [
-            { "col": "A", "name": "name" },
-            { "col": "B", "name": "diagnose" }
-            // ...
-          ],
-          "outSheet": [
-            { "name": "status" }
-            // ...
-          ]
-        }
+        "columns": [
+          { "col": "A", "name": "name" },
+          { "col": "B", "name": "diagnose" }
+          // ...
+        ]
       },
       {
         "kind": "specimen"
@@ -145,13 +139,8 @@ Data from one excel file can be inserted to multiple tables in one database, and
 
 - `kind`: (**required**) is the identifier for the table (the table name will be fetched from environment variable)
 - `columns`: (**required**)
-  - `inSheet`: (**required**) declares fields in database table that has corresponding columns in excel template
-    - `col`: (**required**) the source column in excel template (A, B, C, ...)
-    - `name`: (**required**) the target field in database table
-    - `type`: (**optional**) type of the field if it is not string value (one of `int` or `date`)
-  - `outSheet`: declares fields in database table that does not have corresponding columns in excel template
-    - `name`: (**required**) name of field in database table
-    - `type`: (**optional**) type of field if it is not string value (one of `int` or `date`)
+  - `col`: (**required**) the source column in excel template (A, B, C, ...)
+  - `name`: (**required**) the target field in database table
 
 ## Run in development mode
 

--- a/sheetconfig.json
+++ b/sheetconfig.json
@@ -2,8 +2,8 @@
   {
     "type": "pcr",
     "source": {
-      "headerRow": 3,
-      "startingDataRow": 5,
+      "headerRow": 2,
+      "startingDataRow": 4,
       "columns": [
         { "col": "A", "title": "NO" },
         { "col": "B", "title": "NAME", "constraints": { "presence": true } },
@@ -34,43 +34,27 @@
     "destinations": [
       {
         "kind": "patient",
-        "columns": {
-          "inSheet": [
-            { "col": "B", "name": "name" },
-            { "col": "C", "name": "id_no" },
-            { "col": "D", "name": "birth_date", "type": "date" },
-            { "col": "E", "name": "gender" },
-            { "col": "F", "name": "phone" },
-            { "col": "G", "name": "address" },
-            { "col": "H", "name": "result" }
-          ],
-          "outSheet": [
-            { "name": "created_id" },
-            { "name": "created_date" },
-            { "name": "modified_id" },
-            { "name": "modified_date" }
-          ]
-        }
+        "columns": [
+          { "col": "B", "name": "name" },
+          { "col": "C", "name": "id_no" },
+          { "col": "D", "name": "birth_date" },
+          { "col": "E", "name": "gender" },
+          { "col": "F", "name": "phone" },
+          { "col": "G", "name": "address" },
+          { "col": "H", "name": "result" }
+        ]
       },
       {
         "kind": "specimen",
-        "columns": {
-          "inSheet": [
-            { "col": "B", "name": "name" },
-            { "col": "C", "name": "id_no" },
-            { "col": "D", "name": "birth_date", "type": "date" },
-            { "col": "E", "name": "gender" },
-            { "col": "F", "name": "phone" },
-            { "col": "G", "name": "address" },
-            { "col": "H", "name": "result" }
-          ],
-          "outSheet": [
-            { "name": "created_id" },
-            { "name": "created_date" },
-            { "name": "modified_id" },
-            { "name": "modified_date" }
-          ]
-        }
+        "columns": [
+          { "col": "B", "name": "name" },
+          { "col": "C", "name": "id_no" },
+          { "col": "D", "name": "birth_date" },
+          { "col": "E", "name": "gender" },
+          { "col": "F", "name": "phone" },
+          { "col": "G", "name": "address" },
+          { "col": "H", "name": "result" }
+        ]
       }
     ]
   }

--- a/src/config/sheet.ts
+++ b/src/config/sheet.ts
@@ -33,10 +33,7 @@ export interface SheetConfig {
   }
   destinations: {
     kind: string
-    columns: {
-      inSheet: { col: string; name: string; type?: string }[]
-      outSheet: { name: string; type?: string }[]
-    }
+    columns: { col: string; name: string; type?: string }[]
   }[]
 }
 

--- a/src/config/sheet.ts
+++ b/src/config/sheet.ts
@@ -33,7 +33,7 @@ export interface SheetConfig {
   }
   destinations: {
     kind: string
-    columns: { col: string; name: string; type?: string }[]
+    columns: { col: string; name: string }[]
   }[]
 }
 

--- a/src/service/uploads/handler.ts
+++ b/src/service/uploads/handler.ts
@@ -148,7 +148,7 @@ pubsub.subscribe('onFileHashed', async ({ message, _ }: any) => {
 
         columns.forEach(column => {
           const columnName = column.name
-          const value = normalizeDataType(record[column.col], column.type)
+          const value = record[column.col]
 
           object[columnName] = value
         })
@@ -353,23 +353,6 @@ function removeExtension(fileName: string): string[] {
   )
 
   return fileNameWithoutExtension
-}
-
-function normalizeDataType(value: any, type?: string): any {
-  if (type === 'int') {
-    if (!value) {
-      return 0
-    }
-    return parseInt(value, 10)
-  }
-
-  if (type === 'date') {
-    if (!value) {
-      return '0000-00-00'
-    }
-  }
-
-  return value
 }
 
 function getTable(type: string, kind: string): Table | undefined {

--- a/src/service/uploads/handler.ts
+++ b/src/service/uploads/handler.ts
@@ -313,7 +313,7 @@ async function moveExcelToFailedDir(filePath: string, type: string) {
     filePath,
     path.join(
       path.dirname(filePath),
-      `${storagePath}/${type}/failed/excel/${fileName}`,
+      `${storagePath}/${type}/failed/excel/${fileName}.xlsx`,
     ),
   )
 }

--- a/src/service/uploads/handler.ts
+++ b/src/service/uploads/handler.ts
@@ -146,16 +146,9 @@ pubsub.subscribe('onFileHashed', async ({ message, _ }: any) => {
       for (let { columns, kind } of destinations) {
         let object: Record<string, unknown> = {}
 
-        columns.inSheet.forEach(column => {
+        columns.forEach(column => {
           const columnName = column.name
           const value = normalizeDataType(record[column.col], column.type)
-
-          object[columnName] = value
-        })
-
-        columns.outSheet.forEach(column => {
-          const columnName = column.name
-          const value = normalizeDataType(null, column.type)
 
           object[columnName] = value
         })

--- a/src/service/uploads/handler.ts
+++ b/src/service/uploads/handler.ts
@@ -376,11 +376,7 @@ function normalizeSQLValue(value: any): any {
   return `'${value}'`
 }
 
-function generateDefaultValue(
-  dataType: string,
-  columnType: string,
-  columnDefault?: any,
-) {
+function generateDefaultValue(dataType: string, columnType: string) {
   const stringDataTypes = [
     'char',
     'varchar',
@@ -416,13 +412,7 @@ function generateDefaultValue(
   const isDateTime = dataType == 'datetime'
 
   if (isEnum) {
-    if (typeof columnDefault === 'string') {
-      // remove quote at the beginning and end of string
-      return columnDefault.replace(/^'|'$/g, '')
-    }
-    const match = columnType.match(/^enum\('(.+?)'/)
-    const firstEnumValue = match?.[1]
-    return firstEnumValue
+    return 1
   }
   if (isDate) {
     return '0000-00-00'
@@ -446,13 +436,7 @@ function fillUnmappedColumnToJSON(columnInfo: any, jsonData: any): any {
   const filledData: any = {}
 
   columnInfo.forEach((column: any) => {
-    const {
-      COLUMN_NAME,
-      DATA_TYPE,
-      COLUMN_TYPE,
-      IS_NULLABLE,
-      COLUMN_DEFAULT,
-    } = column
+    const { COLUMN_NAME, DATA_TYPE, COLUMN_TYPE, IS_NULLABLE } = column
     const isColumnExist = Object.keys(jsonData).find(key => key === COLUMN_NAME)
     if (
       isColumnExist &&
@@ -464,11 +448,7 @@ function fillUnmappedColumnToJSON(columnInfo: any, jsonData: any): any {
     }
 
     if (IS_NULLABLE === 'NO') {
-      const defaultValue = generateDefaultValue(
-        DATA_TYPE,
-        COLUMN_TYPE,
-        COLUMN_DEFAULT,
-      )
+      const defaultValue = generateDefaultValue(DATA_TYPE, COLUMN_TYPE)
       filledData[COLUMN_NAME] = defaultValue
     } else {
       filledData[COLUMN_NAME] = null


### PR DESCRIPTION
### Description

- remove outSheet from configuration, so now the columns configuration is no longer
  ```json
   "columns": {
      inSheet: [],
      outSheet: [],  
   }    
  ```
  but just
  ```json
   "columns": [
       { "col": "A", "name": "db_field" },
       ...
   ]
  ```

- remove the need to add `type` in sheetconfig.json because the app now reads table info from database directly

- ~~for enum if it is not nullable and no default defined, the first value from the list of possible values will be used~~