### PR TITLE
Feat: handle numeric date input from excel

### DIFF
--- a/src/internal/sheetValidator.ts
+++ b/src/internal/sheetValidator.ts
@@ -20,6 +20,22 @@
 import validate from 'validate.js'
 import { WorkSheet } from 'xlsx/types'
 
+validate.validators.date = function (value: string | number, options: any) {
+  if (
+    !validate.isDefined(value) ||
+    validate.isNumber(value) // excel auto format date to number as number of days from 1900-01-01
+  ) {
+    return
+  }
+
+  let dateTimeOptions = validate.extend({}, options, { dateOnly: true })
+  return validate.validators.datetime.call(
+    validate.validators.datetime,
+    value,
+    dateTimeOptions,
+  )
+}
+
 export const validateColumns = (
   columns: { col: string; title: string }[],
   headerRow = 1,


### PR DESCRIPTION
### Description

When excel detect a value as date, it will usually format it as date which then parsed by sheetjs as number. This auto format behavior is hard be avoided. So I added a function to check when the input value is a number then it will be converted to date string.

In sheetconfig.json the constraints will be like:
```json
{
    "col": "E",
    "title": "TGL LAHIR",
    "constraints": {
       "date": true
    }
},
```