### PR TITLE
Fix: date constraint causes error

### DIFF
--- a/src/internal/sheetValidator.ts
+++ b/src/internal/sheetValidator.ts
@@ -23,17 +23,20 @@ import { WorkSheet } from 'xlsx/types'
 validate.validators.date = function (value: string | number, options: any) {
   if (
     !validate.isDefined(value) ||
+    validate.isEmpty(value) ||
     validate.isNumber(value) // excel auto format date to number as number of days from 1900-01-01
   ) {
     return
   }
 
-  let dateTimeOptions = validate.extend({}, options, { dateOnly: true })
-  return validate.validators.datetime.call(
-    validate.validators.datetime,
-    value,
-    dateTimeOptions,
-  )
+  if (typeof value === 'string') {
+    const isValid = /^([12]\d{3})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/.test(
+      value,
+    )
+    if (!isValid) {
+      return 'is not a valid date'
+    }
+  }
 }
 
 export const validateColumns = (


### PR DESCRIPTION
### Description

There is this bug when using "date" constraints

```bash
Error: Both the parse and format functions needs to be set to use the datetime/date validator
```

### How did you solve the issue?

I override validate.js `date` constraint completely with a custom function